### PR TITLE
optimization on large folder (with high count of messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ $config['dbmail_fixed_headername_cache'] = FALSE; # add new headernames (if not
 $config["dbmail_cache"] = "db";      // Generic cache switch
 $config["messages_cache"] = TRUE;    // Cache for messages. We don't use it
 $config["dbmail_cache_ttl"] = "10d"; // Cache default expire value
+$config["dbmail_cache_ttl"] = "10d"; // Cache default expire value
+$config["dbmail_messages_disable_cache"]=true //On large folders (with high count of messages) this parameter should be added.
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ $config['dbmail_fixed_headername_cache'] = FALSE; # add new headernames (if not
 $config["dbmail_cache"] = "db";      // Generic cache switch
 $config["messages_cache"] = TRUE;    // Cache for messages. We don't use it
 $config["dbmail_cache_ttl"] = "10d"; // Cache default expire value
-$config["dbmail_cache_ttl"] = "10d"; // Cache default expire value
 $config["dbmail_messages_disable_cache"]=true //On large folders (with high count of messages) this parameter should be added.
 ```
 

--- a/rcube_dbmail.php
+++ b/rcube_dbmail.php
@@ -811,13 +811,20 @@ class rcube_dbmail extends rcube_storage {
             $query .= " INNER JOIN dbmail_physmessage ON dbmail_messages.physmessage_id = dbmail_physmessage.id ";
         }
 
-        $query .= " {$additional_joins} ";
+        $query .= " {$additional_joins} "; 
         $query .= " {$where_conditions} ";
-
+        
+        if ($this->rcubeInstance->config->get('dbmail_messages_disable_cache')){
+            $query .= " group by dbmail_messages.message_idnr "; //patched cc'
+        }
         /*
          * Execute query
          */
         $res = $this->dbmail->query($query);
+        
+        if ($this->rcubeInstance->config->get('dbmail_messages_disable_cache')){
+            return $res->rowCount();
+        }
 
         /*
          * Retrieve full messages count and folder specific messages count


### PR DESCRIPTION
Optimization proposed in cases of folders with high count of messages. 
Currently I have some deployments of DBMail which do have folders of 50000+ messages per folder.
This optimization gives you the opportunity to use roundcube as mail manager. 